### PR TITLE
[v1.28] Update CAPI, golang, rancher/kubectl versions and feature flag

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/golang:1.19-20.21
+FROM registry.suse.com/bci/golang:1.20
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH

--- a/charts-source/capi/Chart.yaml
+++ b/charts-source/capi/Chart.yaml
@@ -5,7 +5,7 @@ home: https://github.com/rancher/provisioning/blob/main/charts/capi/
 sources:
   - "https://github.com/rancher/provisioning/blob/main/charts/capi/"
 version: 0.0.1
-appVersion: "1.4.4"
+appVersion: "1.5.5"
 annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/hidden: "true"
@@ -16,7 +16,7 @@ annotations:
   catalog.cattle.io/permits-os: linux,windows
   catalog.cattle.io/os: linux
   catalog.cattle.io/provides-gvr: apps.deployment/v1
-  catalog.cattle.io/rancher-version: '>= 2.7.0-0'
+  catalog.cattle.io/rancher-version: '>= 2.8.0-0'
 maintainers:
   - email: chris.kim@suse.com
     name: Chris Kim

--- a/charts-source/capi/values.yaml
+++ b/charts-source/capi/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: rancher/mirrored-cluster-api-controller
-  tag: v1.4.4
+  tag: v1.5.5
   imagePullPolicy: IfNotPresent
 
 global:
@@ -8,7 +8,7 @@ global:
     systemDefaultRegistry: ""
   kubectl:
     repository: rancher/kubectl
-    tag: v1.20.2
+    tag: v1.28.5
     pullPolicy: IfNotPresent
 
 # tolerations for the capi-controller-manager deployment. See https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ for more info
@@ -22,4 +22,4 @@ priorityClassName: ""
 extraEnv: []
 args:
   - "--metrics-bind-addr=localhost:8080"
-  - "--feature-gates=MachinePool=false,ClusterResourceSet=false,ClusterTopology=false,RuntimeSDK=false,LazyRestmapper=false"
+  - "--feature-gates=MachinePool=false,ClusterResourceSet=false,ClusterTopology=false,RuntimeSDK=false"

--- a/charts/capi/Chart.yaml
+++ b/charts/capi/Chart.yaml
@@ -5,7 +5,7 @@ home: https://github.com/rancher/provisioning/blob/main/charts/capi/
 sources:
   - "https://github.com/rancher/provisioning/blob/main/charts/capi/"
 version: 0.0.1
-appVersion: "1.4.4"
+appVersion: "1.5.5"
 annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/hidden: "true"
@@ -16,7 +16,7 @@ annotations:
   catalog.cattle.io/permits-os: linux,windows
   catalog.cattle.io/os: linux
   catalog.cattle.io/provides-gvr: apps.deployment/v1
-  catalog.cattle.io/rancher-version: '>= 2.7.0-0'
+  catalog.cattle.io/rancher-version: '>= 2.8.0-0'
 maintainers:
   - email: chris.kim@suse.com
     name: Chris Kim

--- a/charts/capi/values.yaml
+++ b/charts/capi/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: rancher/mirrored-cluster-api-controller
-  tag: v1.4.4
+  tag: v1.5.5
   imagePullPolicy: IfNotPresent
 
 global:
@@ -8,7 +8,7 @@ global:
     systemDefaultRegistry: ""
   kubectl:
     repository: rancher/kubectl
-    tag: v1.20.2
+    tag: v1.28.5
     pullPolicy: IfNotPresent
 
 # tolerations for the capi-controller-manager deployment. See https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ for more info
@@ -22,4 +22,4 @@ priorityClassName: ""
 extraEnv: []
 args:
   - "--metrics-bind-addr=localhost:8080"
-  - "--feature-gates=MachinePool=false,ClusterResourceSet=false,ClusterTopology=false,RuntimeSDK=false,LazyRestmapper=false"
+  - "--feature-gates=MachinePool=false,ClusterResourceSet=false,ClusterTopology=false,RuntimeSDK=false"

--- a/scripts/capi-chart
+++ b/scripts/capi-chart
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Must also set the corresponding versions in Chart.yaml and values.yaml
-CAPI_VERSION=v1.4.4
+CAPI_VERSION=v1.5.5
 
 # Script requires yq >= 4.x
 if ! [ -x "$(command -v yq)" ]; then


### PR DESCRIPTION
### Update
* CAPI to 1.5.5 
* golang to 1.20
* rancher/kubectl to v1.28.5
* Remove `LazyRestmapper` feature flag for capi v4 to v5 migration, [Context](https://cluster-api.sigs.k8s.io/developer/providers/migrations/v1.4-to-v1.5#removals).
* TODO QA Test: Test Rancher on hardened clusters with the minimum supported K8s version.

### Related
* https://github.com/rancher/rancher/issues/43109