### PR TITLE
[v1.28] Update minimum rancher-version, kube-version and helm chart version

### DIFF
--- a/charts-source/capi/Chart.yaml
+++ b/charts-source/capi/Chart.yaml
@@ -4,19 +4,19 @@ description: capi-controller-manager compatible with Rancher Provisioning
 home: https://github.com/rancher/provisioning/blob/main/charts/capi/
 sources:
   - "https://github.com/rancher/provisioning/blob/main/charts/capi/"
-version: 0.0.1
+version: 0.1.0
 appVersion: "1.5.5"
 annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/hidden: "true"
   catalog.cattle.io/display-name: Rancher Provisioning CAPI Controller Manager
-  catalog.cattle.io/kube-version: '>=1.23.0-0'
+  catalog.cattle.io/kube-version: '>=1.24.0-0'
   catalog.cattle.io/namespace: cattle-provisioning-capi-system
   catalog.cattle.io/release-name: rancher-provisioning-capi
   catalog.cattle.io/permits-os: linux,windows
   catalog.cattle.io/os: linux
   catalog.cattle.io/provides-gvr: apps.deployment/v1
-  catalog.cattle.io/rancher-version: '>= 2.8.0-0'
+  catalog.cattle.io/rancher-version: '>= 2.8.3-0'
 maintainers:
   - email: chris.kim@suse.com
     name: Chris Kim

--- a/charts/capi/Chart.yaml
+++ b/charts/capi/Chart.yaml
@@ -4,19 +4,19 @@ description: capi-controller-manager compatible with Rancher Provisioning
 home: https://github.com/rancher/provisioning/blob/main/charts/capi/
 sources:
   - "https://github.com/rancher/provisioning/blob/main/charts/capi/"
-version: 0.0.1
+version: 0.1.0
 appVersion: "1.5.5"
 annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/hidden: "true"
   catalog.cattle.io/display-name: Rancher Provisioning CAPI Controller Manager
-  catalog.cattle.io/kube-version: '>=1.23.0-0'
+  catalog.cattle.io/kube-version: '>=1.24.0-0'
   catalog.cattle.io/namespace: cattle-provisioning-capi-system
   catalog.cattle.io/release-name: rancher-provisioning-capi
   catalog.cattle.io/permits-os: linux,windows
   catalog.cattle.io/os: linux
   catalog.cattle.io/provides-gvr: apps.deployment/v1
-  catalog.cattle.io/rancher-version: '>= 2.8.0-0'
+  catalog.cattle.io/rancher-version: '>= 2.8.3-0'
 maintainers:
   - email: chris.kim@suse.com
     name: Chris Kim


### PR DESCRIPTION
### Update
* Minimum rancher-version to `v2.8.3`
* Minimum kube-version to `v1.24.0`. [support matrix](https://cluster-api.sigs.k8s.io/reference/versions#release-components)
* Helm chart to `0.1.0`

### Related
* https://github.com/rancher/rancher/issues/43109