### PR TITLE
bump bci/golang tag to 1.21-2.2.25

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/golang:1.20
+FROM registry.suse.com/bci/golang:1.21-2.2.25
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH


### PR DESCRIPTION
bump bci/golang tag to 1.21-2.2.25

Dev test:

Running `make` passed and did not cause any file change in the repo.