### PR TITLE
[v2.7] bump bci/golang tag to 1.21 instead of a specific patch tag 

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/golang:1.21-2.2.25
+FROM registry.suse.com/bci/golang:1.21
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH


### PR DESCRIPTION
bump bci/golang tag to 1.21 instead of a specific patch tag 

this is a follow-up PR for https://github.com/rancher/provisioning/pull/6