### PR TITLE
[v1.29] Update CAPI & rancher/kubectl versions

### DIFF
--- a/charts-source/capi/Chart.yaml
+++ b/charts-source/capi/Chart.yaml
@@ -4,8 +4,8 @@ description: capi-controller-manager compatible with Rancher Provisioning
 home: https://github.com/rancher/provisioning/blob/main/charts/capi/
 sources:
   - "https://github.com/rancher/provisioning/blob/main/charts/capi/"
-version: 0.1.0
-appVersion: "1.5.5"
+version: 0.2.0
+appVersion: "1.6.4"
 annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/hidden: "true"
@@ -16,7 +16,7 @@ annotations:
   catalog.cattle.io/permits-os: linux,windows
   catalog.cattle.io/os: linux
   catalog.cattle.io/provides-gvr: apps.deployment/v1
-  catalog.cattle.io/rancher-version: '>= 2.8.3-0'
+  catalog.cattle.io/rancher-version: '>= 2.9.0-0'
 maintainers:
   - email: chris.kim@suse.com
     name: Chris Kim

--- a/charts-source/capi/values.yaml
+++ b/charts-source/capi/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: rancher/mirrored-cluster-api-controller
-  tag: v1.5.5
+  tag: v1.6.4
   imagePullPolicy: IfNotPresent
 
 global:
@@ -8,7 +8,7 @@ global:
     systemDefaultRegistry: ""
   kubectl:
     repository: rancher/kubectl
-    tag: v1.28.5
+    tag: v1.29.2
     pullPolicy: IfNotPresent
 
 # tolerations for the capi-controller-manager deployment. See https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ for more info

--- a/charts/capi/Chart.yaml
+++ b/charts/capi/Chart.yaml
@@ -4,8 +4,8 @@ description: capi-controller-manager compatible with Rancher Provisioning
 home: https://github.com/rancher/provisioning/blob/main/charts/capi/
 sources:
   - "https://github.com/rancher/provisioning/blob/main/charts/capi/"
-version: 0.1.0
-appVersion: "1.5.5"
+version: 0.2.0
+appVersion: "1.6.4"
 annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/hidden: "true"
@@ -16,7 +16,7 @@ annotations:
   catalog.cattle.io/permits-os: linux,windows
   catalog.cattle.io/os: linux
   catalog.cattle.io/provides-gvr: apps.deployment/v1
-  catalog.cattle.io/rancher-version: '>= 2.8.3-0'
+  catalog.cattle.io/rancher-version: '>= 2.9.0-0'
 maintainers:
   - email: chris.kim@suse.com
     name: Chris Kim

--- a/charts/capi/values.yaml
+++ b/charts/capi/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: rancher/mirrored-cluster-api-controller
-  tag: v1.5.5
+  tag: v1.6.4
   imagePullPolicy: IfNotPresent
 
 global:
@@ -8,7 +8,7 @@ global:
     systemDefaultRegistry: ""
   kubectl:
     repository: rancher/kubectl
-    tag: v1.28.5
+    tag: v1.29.2
     pullPolicy: IfNotPresent
 
 # tolerations for the capi-controller-manager deployment. See https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ for more info

--- a/scripts/capi-chart
+++ b/scripts/capi-chart
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Must also set the corresponding versions in Chart.yaml and values.yaml
-CAPI_VERSION=v1.5.5
+CAPI_VERSION=v1.6.4
 
 # Script requires yq >= 4.x
 if ! [ -x "$(command -v yq)" ]; then


### PR DESCRIPTION
### Updates

- Bump CAPI `v1.6.4`
- Bump `rancher/kubectl` to `v1.29.2`

### Related

- https://github.com/rancher/rancher/issues/43110
