### PR TITLE
[v1.29] change rancher-version & kube-version

### DIFF
--- a/charts-source/capi/Chart.yaml
+++ b/charts-source/capi/Chart.yaml
@@ -10,13 +10,13 @@ annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/hidden: "true"
   catalog.cattle.io/display-name: Rancher Provisioning CAPI Controller Manager
-  catalog.cattle.io/kube-version: '>=1.24.0-0'
+  catalog.cattle.io/kube-version: '>=1.27.0-0'
   catalog.cattle.io/namespace: cattle-provisioning-capi-system
   catalog.cattle.io/release-name: rancher-provisioning-capi
   catalog.cattle.io/permits-os: linux,windows
   catalog.cattle.io/os: linux
   catalog.cattle.io/provides-gvr: apps.deployment/v1
-  catalog.cattle.io/rancher-version: '>= 2.9.0-0'
+  catalog.cattle.io/rancher-version: '>= 2.9.0-0 < 2.10.0-0'
 maintainers:
   - email: chris.kim@suse.com
     name: Chris Kim

--- a/charts/capi/Chart.yaml
+++ b/charts/capi/Chart.yaml
@@ -10,13 +10,13 @@ annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/hidden: "true"
   catalog.cattle.io/display-name: Rancher Provisioning CAPI Controller Manager
-  catalog.cattle.io/kube-version: '>=1.24.0-0'
+  catalog.cattle.io/kube-version: '>=1.27.0-0'
   catalog.cattle.io/namespace: cattle-provisioning-capi-system
   catalog.cattle.io/release-name: rancher-provisioning-capi
   catalog.cattle.io/permits-os: linux,windows
   catalog.cattle.io/os: linux
   catalog.cattle.io/provides-gvr: apps.deployment/v1
-  catalog.cattle.io/rancher-version: '>= 2.9.0-0'
+  catalog.cattle.io/rancher-version: '>= 2.9.0-0 < 2.10.0-0'
 maintainers:
   - email: chris.kim@suse.com
     name: Chris Kim


### PR DESCRIPTION
### Updates

- change `catalog.cattle.io/kube-version: '>=1.27.0-0'`
- change `catalog.cattle.io/rancher-version: '>= 2.9.0-0 < 2.10.0-0'`

### Related

- https://github.com/rancher/rancher/issues/43859
- https://github.com/rancher/rancher/issues/43110
