### PR TITLE
CAPI v1.7.3

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/golang:1.21
+FROM registry.suse.com/bci/golang:1.22
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH

--- a/charts-source/capi/Chart.yaml
+++ b/charts-source/capi/Chart.yaml
@@ -5,12 +5,12 @@ home: https://github.com/rancher/provisioning/blob/main/charts/capi/
 sources:
   - "https://github.com/rancher/provisioning/blob/main/charts/capi/"
 version: 0.2.0
-appVersion: "1.6.4"
+appVersion: "1.7.3"
 annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/hidden: "true"
   catalog.cattle.io/display-name: Rancher Provisioning CAPI Controller Manager
-  catalog.cattle.io/kube-version: '>=1.27.0-0'
+  catalog.cattle.io/kube-version: '>= 1.27.0-0 < 1.31.0-0'
   catalog.cattle.io/namespace: cattle-provisioning-capi-system
   catalog.cattle.io/release-name: rancher-provisioning-capi
   catalog.cattle.io/permits-os: linux,windows

--- a/charts-source/capi/values.yaml
+++ b/charts-source/capi/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: rancher/mirrored-cluster-api-controller
-  tag: v1.6.4
+  tag: v1.7.3
   imagePullPolicy: IfNotPresent
 
 global:

--- a/charts/capi/Chart.yaml
+++ b/charts/capi/Chart.yaml
@@ -5,12 +5,12 @@ home: https://github.com/rancher/provisioning/blob/main/charts/capi/
 sources:
   - "https://github.com/rancher/provisioning/blob/main/charts/capi/"
 version: 0.2.0
-appVersion: "1.6.4"
+appVersion: "1.7.3"
 annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/hidden: "true"
   catalog.cattle.io/display-name: Rancher Provisioning CAPI Controller Manager
-  catalog.cattle.io/kube-version: '>=1.27.0-0'
+  catalog.cattle.io/kube-version: '>= 1.27.0-0 < 1.31.0-0'
   catalog.cattle.io/namespace: cattle-provisioning-capi-system
   catalog.cattle.io/release-name: rancher-provisioning-capi
   catalog.cattle.io/permits-os: linux,windows

--- a/charts/capi/templates/clusterrole-capi-manager-role.yaml
+++ b/charts/capi/templates/clusterrole-capi-manager-role.yaml
@@ -44,6 +44,18 @@ rules:
       - list
       - watch
   - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+  - apiGroups:
       - bootstrap.cluster.x-k8s.io
       - controlplane.cluster.x-k8s.io
       - infrastructure.cluster.x-k8s.io
@@ -184,6 +196,18 @@ rules:
       - machinehealthchecks/finalizers
       - machinehealthchecks/status
     verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - cluster.x-k8s.io
+    resources:
+      - machinepools
+    verbs:
+      - create
+      - delete
       - get
       - list
       - patch

--- a/charts/capi/templates/deployment-capi-controller-manager.yaml
+++ b/charts/capi/templates/deployment-capi-controller-manager.yaml
@@ -50,6 +50,9 @@ spec:
             - containerPort: 9440
               name: healthz
               protocol: TCP
+            - containerPort: 8443
+              name: metrics
+              protocol: TCP
           readinessProbe:
             httpGet:
               path: /readyz

--- a/charts/capi/values.yaml
+++ b/charts/capi/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: rancher/mirrored-cluster-api-controller
-  tag: v1.6.4
+  tag: v1.7.3
   imagePullPolicy: IfNotPresent
 
 global:

--- a/scripts/capi-chart
+++ b/scripts/capi-chart
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Must also set the corresponding versions in Chart.yaml and values.yaml
-CAPI_VERSION=v1.6.4
+CAPI_VERSION=v1.7.3
 
 # Script requires yq >= 4.x
 if ! [ -x "$(command -v yq)" ]; then


### PR DESCRIPTION
issue: https://github.com/rancher/rancher/issues/45089
-  bumping the version since capi v1.7.x officially supports v1.30.
- updated go image to 1.22