### PR TITLE
Add managed annotation to the chart

### DIFF
--- a/charts-source/capi/Chart.yaml
+++ b/charts-source/capi/Chart.yaml
@@ -4,11 +4,12 @@ description: capi-controller-manager compatible with Rancher Provisioning
 home: https://github.com/rancher/provisioning/blob/main/charts/capi/
 sources:
   - "https://github.com/rancher/provisioning/blob/main/charts/capi/"
-version: 0.5.0
+version: 0.6.0
 appVersion: "1.8.3"
 annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/hidden: "true"
+  catalog.cattle.io/managed: "true"
   catalog.cattle.io/display-name: Rancher Provisioning CAPI Controller Manager
   catalog.cattle.io/kube-version: '>= 1.27.0-0 < 1.32.0-0'
   catalog.cattle.io/namespace: cattle-provisioning-capi-system

--- a/charts/capi/Chart.yaml
+++ b/charts/capi/Chart.yaml
@@ -4,11 +4,12 @@ description: capi-controller-manager compatible with Rancher Provisioning
 home: https://github.com/rancher/provisioning/blob/main/charts/capi/
 sources:
   - "https://github.com/rancher/provisioning/blob/main/charts/capi/"
-version: 0.5.0
+version: 0.6.0
 appVersion: "1.8.3"
 annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/hidden: "true"
+  catalog.cattle.io/managed: "true"
   catalog.cattle.io/display-name: Rancher Provisioning CAPI Controller Manager
   catalog.cattle.io/kube-version: '>= 1.27.0-0 < 1.32.0-0'
   catalog.cattle.io/namespace: cattle-provisioning-capi-system


### PR DESCRIPTION
Add managed annotation to the chart

This annotation is used by rancher/dashboard to issue warnings when manually upgrading or deleting the chart, since the chart is managed by rancher and doesn't support these actions.

I tested this by checking that warnings appear when the chart has this annotation:

![delete-after](https://github.com/user-attachments/assets/17c96b57-ee46-4c52-baff-056437de9469)
![managed_after](https://github.com/user-attachments/assets/9c52f158-3726-4ff1-af4a-62c488c9b20b)
![upgrade-after](https://github.com/user-attachments/assets/076468cc-ddd5-43b2-aedc-158b68516da3)

These did not appear before.

https://github.com/rancher/rancher/issues/44353