### PR TITLE
[v2.9] Backport: Add managed annotation to the chart

### DIFF
--- a/charts-source/capi/Chart.yaml
+++ b/charts-source/capi/Chart.yaml
@@ -4,11 +4,12 @@ description: capi-controller-manager compatible with Rancher Provisioning
 home: https://github.com/rancher/provisioning/blob/main/charts/capi/
 sources:
   - "https://github.com/rancher/provisioning/blob/main/charts/capi/"
-version: 0.3.0
+version: 0.3.1
 appVersion: "1.7.3"
 annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/hidden: "true"
+  catalog.cattle.io/managed: "true"
   catalog.cattle.io/display-name: Rancher Provisioning CAPI Controller Manager
   catalog.cattle.io/kube-version: '>= 1.27.0-0 < 1.31.0-0'
   catalog.cattle.io/namespace: cattle-provisioning-capi-system

--- a/charts/capi/Chart.yaml
+++ b/charts/capi/Chart.yaml
@@ -4,11 +4,12 @@ description: capi-controller-manager compatible with Rancher Provisioning
 home: https://github.com/rancher/provisioning/blob/main/charts/capi/
 sources:
   - "https://github.com/rancher/provisioning/blob/main/charts/capi/"
-version: 0.3.0
+version: 0.3.1
 appVersion: "1.7.3"
 annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/hidden: "true"
+  catalog.cattle.io/managed: "true"
   catalog.cattle.io/display-name: Rancher Provisioning CAPI Controller Manager
   catalog.cattle.io/kube-version: '>= 1.27.0-0 < 1.31.0-0'
   catalog.cattle.io/namespace: cattle-provisioning-capi-system


### PR DESCRIPTION
Backport of https://github.com/rancher/provisioning/pull/16

This isn't a simple cherry-pick, because I had to alter the version, and I only cherry-picked the changes in `charts-source` and generated the changes in `charts`.

In the main branch, I had bumped the minor version, but I can't do this here, otherwise, the version will conflict with the existing 0.4.0, which is meant for v2.10 rancher. It's a bit ugly, but I bumped the patch version for this backport.

Issue: https://github.com/rancher/rancher/issues/44353