### PR TITLE
[v1.32] Bump CAPI to `v1.9.4`

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,9 +1,9 @@
-FROM registry.suse.com/bci/golang:1.22
+FROM registry.suse.com/bci/golang:1.23
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH
 
-ENV YQ_VERSION v4.34.2
+ENV YQ_VERSION v4.45.1
 
 RUN zypper -n install git docker vim less file curl wget
 RUN wget https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${ARCH}.tar.gz -O - | tar xz && mv yq_linux_${ARCH} /usr/bin/yq

--- a/charts-source/capi/Chart.yaml
+++ b/charts-source/capi/Chart.yaml
@@ -4,20 +4,20 @@ description: capi-controller-manager compatible with Rancher Provisioning
 home: https://github.com/rancher/provisioning/blob/main/charts/capi/
 sources:
   - "https://github.com/rancher/provisioning/blob/main/charts/capi/"
-version: 0.6.0
-appVersion: "1.8.3"
+version: 0.7.0
+appVersion: "1.9.4"
 annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/hidden: "true"
   catalog.cattle.io/managed: "true"
   catalog.cattle.io/display-name: Rancher Provisioning CAPI Controller Manager
-  catalog.cattle.io/kube-version: '>= 1.27.0-0 < 1.32.0-0'
+  catalog.cattle.io/kube-version: '>= 1.32.0-0 < 1.33.0-0'
   catalog.cattle.io/namespace: cattle-provisioning-capi-system
   catalog.cattle.io/release-name: rancher-provisioning-capi
   catalog.cattle.io/permits-os: linux,windows
   catalog.cattle.io/os: linux
   catalog.cattle.io/provides-gvr: apps.deployment/v1
-  catalog.cattle.io/rancher-version: '>= 2.10.0-0 < 2.11.0-0'
+  catalog.cattle.io/rancher-version: '>= 2.11.0-0 < 2.12.0-0'
 maintainers:
   - email: chris.kim@suse.com
     name: Chris Kim

--- a/charts-source/capi/values.yaml
+++ b/charts-source/capi/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: rancher/mirrored-cluster-api-controller
-  tag: v1.8.3
+  tag: v1.9.4
   imagePullPolicy: IfNotPresent
 
 global:
@@ -8,7 +8,7 @@ global:
     systemDefaultRegistry: ""
   kubectl:
     repository: rancher/kubectl
-    tag: v1.29.2
+    tag: v1.32.1
     pullPolicy: IfNotPresent
 
 # tolerations for the capi-controller-manager deployment. See https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ for more info
@@ -21,5 +21,5 @@ priorityClassName: ""
 
 extraEnv: []
 args:
-  - "--metrics-bind-addr=localhost:8080"
+  - "--diagnostics-address=localhost:8443"
   - "--feature-gates=MachinePool=false,ClusterResourceSet=false,ClusterTopology=false,RuntimeSDK=false"

--- a/charts/capi/Chart.yaml
+++ b/charts/capi/Chart.yaml
@@ -4,20 +4,20 @@ description: capi-controller-manager compatible with Rancher Provisioning
 home: https://github.com/rancher/provisioning/blob/main/charts/capi/
 sources:
   - "https://github.com/rancher/provisioning/blob/main/charts/capi/"
-version: 0.6.0
-appVersion: "1.8.3"
+version: 0.7.0
+appVersion: "1.9.4"
 annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/hidden: "true"
   catalog.cattle.io/managed: "true"
   catalog.cattle.io/display-name: Rancher Provisioning CAPI Controller Manager
-  catalog.cattle.io/kube-version: '>= 1.27.0-0 < 1.32.0-0'
+  catalog.cattle.io/kube-version: '>= 1.32.0-0 < 1.33.0-0'
   catalog.cattle.io/namespace: cattle-provisioning-capi-system
   catalog.cattle.io/release-name: rancher-provisioning-capi
   catalog.cattle.io/permits-os: linux,windows
   catalog.cattle.io/os: linux
   catalog.cattle.io/provides-gvr: apps.deployment/v1
-  catalog.cattle.io/rancher-version: '>= 2.10.0-0 < 2.11.0-0'
+  catalog.cattle.io/rancher-version: '>= 2.11.0-0 < 2.12.0-0'
 maintainers:
   - email: chris.kim@suse.com
     name: Chris Kim

--- a/charts/capi/templates/clusterrole-capi-manager-role.yaml
+++ b/charts/capi/templates/clusterrole-capi-manager-role.yaml
@@ -17,6 +17,18 @@ rules:
   - apiGroups:
       - addons.cluster.x-k8s.io
     resources:
+      - clusterresourcesets/finalizers
+      - clusterresourcesets/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - addons.cluster.x-k8s.io
+      - bootstrap.cluster.x-k8s.io
+      - controlplane.cluster.x-k8s.io
+      - infrastructure.cluster.x-k8s.io
+    resources:
       - '*'
     verbs:
       - create
@@ -26,15 +38,6 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
-      - addons.cluster.x-k8s.io
-    resources:
-      - clusterresourcesets/finalizers
-      - clusterresourcesets/status
-    verbs:
-      - get
-      - patch
-      - update
   - apiGroups:
       - apiextensions.k8s.io
     resources:
@@ -56,101 +59,15 @@ rules:
     verbs:
       - create
   - apiGroups:
-      - bootstrap.cluster.x-k8s.io
-      - controlplane.cluster.x-k8s.io
-      - infrastructure.cluster.x-k8s.io
-    resources:
-      - '*'
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - bootstrap.cluster.x-k8s.io
-      - infrastructure.cluster.x-k8s.io
-    resources:
-      - '*'
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - cluster.x-k8s.io
-    resources:
-      - clusterclasses
-    verbs:
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
       - cluster.x-k8s.io
     resources:
       - clusterclasses
       - clusterclasses/status
-    verbs:
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - cluster.x-k8s.io
-    resources:
-      - clusters
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - cluster.x-k8s.io
-    resources:
       - clusters
       - clusters/finalizers
       - clusters/status
-    verbs:
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - cluster.x-k8s.io
-    resources:
-      - clusters
-      - clusters/status
-    verbs:
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - cluster.x-k8s.io
-    resources:
-      - machinedeployments
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - cluster.x-k8s.io
-    resources:
-      - machinedeployments
-      - machinedeployments/finalizers
+      - machinehealthchecks/finalizers
+      - machinehealthchecks/status
     verbs:
       - get
       - list
@@ -163,110 +80,13 @@ rules:
       - machinedeployments
       - machinedeployments/finalizers
       - machinedeployments/status
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - cluster.x-k8s.io
-    resources:
       - machinehealthchecks
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - cluster.x-k8s.io
-    resources:
-      - machinehealthchecks
-      - machinehealthchecks/finalizers
-      - machinehealthchecks/status
-    verbs:
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - cluster.x-k8s.io
-    resources:
-      - machinepools
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - cluster.x-k8s.io
-    resources:
       - machinepools
       - machinepools/finalizers
       - machinepools/status
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - cluster.x-k8s.io
-    resources:
       - machines
       - machines/finalizers
       - machines/status
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - cluster.x-k8s.io
-    resources:
-      - machines
-      - machines/status
-    verbs:
-      - delete
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - cluster.x-k8s.io
-    resources:
-      - machinesets
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - cluster.x-k8s.io
-    resources:
-      - machinesets
-      - machinesets/finalizers
-    verbs:
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - cluster.x-k8s.io
-    resources:
       - machinesets
       - machinesets/finalizers
       - machinesets/status
@@ -277,6 +97,14 @@ rules:
       - list
       - patch
       - update
+      - watch
+  - apiGroups:
+      - cluster.x-k8s.io
+    resources:
+      - machinedrainrules
+    verbs:
+      - get
+      - list
       - watch
   - apiGroups:
       - ""

--- a/charts/capi/values.yaml
+++ b/charts/capi/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: rancher/mirrored-cluster-api-controller
-  tag: v1.8.3
+  tag: v1.9.4
   imagePullPolicy: IfNotPresent
 
 global:
@@ -8,7 +8,7 @@ global:
     systemDefaultRegistry: ""
   kubectl:
     repository: rancher/kubectl
-    tag: v1.29.2
+    tag: v1.32.1
     pullPolicy: IfNotPresent
 
 # tolerations for the capi-controller-manager deployment. See https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ for more info
@@ -21,5 +21,5 @@ priorityClassName: ""
 
 extraEnv: []
 args:
-  - "--metrics-bind-addr=localhost:8080"
+  - "--diagnostics-address=localhost:8443"
   - "--feature-gates=MachinePool=false,ClusterResourceSet=false,ClusterTopology=false,RuntimeSDK=false"

--- a/scripts/capi-chart
+++ b/scripts/capi-chart
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Must also set the corresponding versions in Chart.yaml and values.yaml
-CAPI_VERSION=v1.8.3
+CAPI_VERSION=v1.9.4
 
 # Script requires yq >= 4.x
 if ! [ -x "$(command -v yq)" ]; then


### PR DESCRIPTION
### Updates
- Bump CAPI to v1.9.4
- Update deprecated flag `--metrics-bind-addr` with `--diagnostics-address=localhost:8443`
- make capi-charts

### Issue:
- https://github.com/rancher/rancher/issues/47934